### PR TITLE
Fix TrueType outline conversion and left side bearing (0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
   TrueType (`useOpenType: false`) requires `hmtx.lsb == glyf.xMin`; a
   mismatch shifts a glyph sideways when rendered. This affects TrueType
   output in **both** `normalize` modes: with `normalize: true`, centring
-  zeroes a glyph's *pre-conversion* `xMin`, but curved outlines can still
-  land a fraction of a font unit off zero once quadratic-approximated, so
-  the two need not coincide. `normalize: false` output changes for CFF
+  zeroes a glyph's *pre-conversion* `xMin`, but a curved outline can still
+  land several font units off zero once quadratic-approximated, so the two
+  need not coincide. `normalize: false` output changes for CFF
   (OpenType) fonts too — `hmtx.lsb`, the `head` bounding box, and `hhea`'s
   right-side-bearing/extent now reflect each glyph's real ink bounds
   instead of a placeholder that assumed every custom glyph filled its whole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.2
+
+* Fix TrueType (`useOpenType: false`) output storing SVG cubic control points
+  verbatim as consecutive quadratic off-curve points instead of converting
+  them, which bulged curved outlines outward (a full circle overshot its
+  radius by close to 10% at the diagonals).
+* Fix `hmtx.lsb` being hardcoded to zero instead of the glyph's real `xMin`.
+  TrueType requires `hmtx.lsb == glyf.xMin`; a mismatch shifts a glyph
+  sideways when rendered. Only visible with `normalize: false`, where the
+  artboard is mapped onto the em square without centring.
+
 ## 0.5.1
 
 * `normalize` defaults to **true** again (uniform em fill). Pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@
   them, which bulged curved outlines outward (a full circle overshot its
   radius by close to 10% at the diagonals).
 * Fix `hmtx.lsb` being hardcoded to zero instead of the glyph's real `xMin`.
-  TrueType requires `hmtx.lsb == glyf.xMin`; a mismatch shifts a glyph
-  sideways when rendered. Only visible with `normalize: false`, where the
-  artboard is mapped onto the em square without centring.
+  TrueType (`useOpenType: false`) requires `hmtx.lsb == glyf.xMin`; a
+  mismatch shifts a glyph sideways when rendered. This affects TrueType
+  output in **both** `normalize` modes: with `normalize: true`, centring
+  zeroes a glyph's *pre-conversion* `xMin`, but curved outlines can still
+  land a fraction of a font unit off zero once quadratic-approximated, so
+  the two need not coincide. `normalize: false` output changes for CFF
+  (OpenType) fonts too — `hmtx.lsb`, the `head` bounding box, and `hhea`'s
+  right-side-bearing/extent now reflect each glyph's real ink bounds
+  instead of a placeholder that assumed every custom glyph filled its whole
+  em square; advance widths are unchanged in every mode and format.
 
 ## 0.5.1
 

--- a/lib/src/otf/otf_builder.dart
+++ b/lib/src/otf/otf_builder.dart
@@ -110,10 +110,27 @@ class OpenTypeFontBuilder {
       revision,
       unitsPerEm,
     );
+
+    // TrueType requires hmtx.lsb == glyf.xMin. glyphMetricsList's xMin comes
+    // from each glyph's pre-cubicToQuad outline (see build()), but glyf's
+    // own xMin — read here from the SimpleGlyph the encoder already built —
+    // is computed from the post-conversion quadratic points, a different
+    // point set whose bounding box need not coincide with the cubic one's.
+    // Source lsb from glyf directly rather than reconciling the two metrics.
+    //
+    // CFF's charstrings are encoded straight from the same unconverted
+    // cubic outlines glyphMetricsList reflects, so its lsb is left deriving
+    // from glyphMetricsList unchanged — there is no second, divergent point
+    // set to reconcile there.
+    final lsbOverrides = glyf == null
+        ? null
+        : [for (final g in glyf.glyphList) g.isEmpty ? null : g.header.xMin];
+
     final hmtx = HorizontalMetricsTable.create(
       glyphMetricsList,
       unitsPerEm,
       advanceWidthOverrides: advanceWidthOverrides,
+      lsbOverrides: lsbOverrides,
     );
     final hhea = HorizontalHeaderTable.create(
       glyphMetricsList,

--- a/lib/src/otf/otf_builder.dart
+++ b/lib/src/otf/otf_builder.dart
@@ -60,22 +60,29 @@ class OpenTypeFontBuilder {
     final defaultGlyphList = generateDefaultGlyphList(ascender);
     final fullGlyphList = [...defaultGlyphList, ...resizedGlyphList];
 
+    // Every glyph's own bounding box — never overridden. hmtx.lsb, the head
+    // bbox and hhea's rsb/extent all need the real xMin/xMax to stay
+    // internally consistent (in particular, TrueType requires
+    // hmtx.lsb == glyf.xMin); only the advance width has a legitimate reason
+    // to differ from it, handled below via [advanceWidthOverrides].
     final glyphMetricsList = [
       for (final glyph in defaultGlyphList) glyph.metrics,
-      // If normalization is off every custom glyph's size equals unitsPerEm
-      if (normalize)
-        for (final glyph in resizedGlyphList) glyph.metrics
-      else
-        ...List.filled(
-          resizedGlyphList.length,
-          GenericGlyphMetrics.square(unitsPerEm),
-        ),
+      for (final glyph in resizedGlyphList) glyph.metrics,
+    ];
+
+    // Without normalization every custom glyph advances by the full em
+    // regardless of how much of it its own ink fills — the artboard fitting
+    // keeps a uniform grid instead of tightening around each icon.
+    final advanceWidthOverrides = <int?>[
+      ...List.filled(defaultGlyphList.length, null),
+      ...List.filled(resizedGlyphList.length, normalize ? null : unitsPerEm),
     ];
 
     final tables = _buildTables(
       fullGlyphList: fullGlyphList,
       resizedGlyphList: resizedGlyphList,
       glyphMetricsList: glyphMetricsList,
+      advanceWidthOverrides: advanceWidthOverrides,
       unitsPerEm: unitsPerEm,
       ascender: ascender,
       descender: descender,
@@ -91,6 +98,7 @@ class OpenTypeFontBuilder {
     required List<GenericGlyph> fullGlyphList,
     required List<GenericGlyph> resizedGlyphList,
     required List<GenericGlyphMetrics> glyphMetricsList,
+    required List<int?> advanceWidthOverrides,
     required int unitsPerEm,
     required int ascender,
     required int descender,
@@ -102,7 +110,11 @@ class OpenTypeFontBuilder {
       revision,
       unitsPerEm,
     );
-    final hmtx = HorizontalMetricsTable.create(glyphMetricsList, unitsPerEm);
+    final hmtx = HorizontalMetricsTable.create(
+      glyphMetricsList,
+      unitsPerEm,
+      advanceWidthOverrides: advanceWidthOverrides,
+    );
     final hhea = HorizontalHeaderTable.create(
       glyphMetricsList,
       hmtx,

--- a/lib/src/otf/table/glyf.dart
+++ b/lib/src/otf/table/glyf.dart
@@ -47,7 +47,10 @@ class GlyphDataTable extends FontTable {
   }
 
   factory GlyphDataTable.fromGlyphs(List<GenericGlyph> glyphList) {
-    final glyphListCopy = glyphList.map((e) => e.copy());
+    // Eager: the loop below mutates each copy in place via cubicToQuad and
+    // compactImplicitPoints. A lazy Iterable would hand the map below a
+    // second, unconverted batch of copies instead of these mutated ones.
+    final glyphListCopy = glyphList.map((e) => e.copy()).toList();
 
     for (final glyph in glyphListCopy) {
       for (final outline in glyph.outlines) {

--- a/lib/src/otf/table/hmtx.dart
+++ b/lib/src/otf/table/hmtx.dart
@@ -22,15 +22,25 @@ class LongHorMetric implements BinaryCodable {
     );
   }
 
+  /// [advanceWidthOverride], when given, replaces the width that would
+  /// otherwise be derived from [metrics] — used when a glyph must advance by
+  /// a fixed amount (e.g. a full em) regardless of how much of it its own
+  /// ink fills. [lsb] always tracks the glyph's real [GenericGlyphMetrics.xMin]
+  /// so it stays equal to `glyf.xMin`, which TrueType requires.
   factory LongHorMetric.createForGlyph(
     GenericGlyphMetrics metrics,
-    int unitsPerEm,
-  ) {
-    if (metrics.width == 0) {
-      return LongHorMetric(unitsPerEm ~/ 3, 0);
+    int unitsPerEm, {
+    int? advanceWidthOverride,
+  }) {
+    if (advanceWidthOverride != null) {
+      return LongHorMetric(advanceWidthOverride, metrics.xMin);
     }
 
-    return LongHorMetric(metrics.xMax - metrics.xMin, 0);
+    if (metrics.width == 0) {
+      return LongHorMetric(unitsPerEm ~/ 3, metrics.xMin);
+    }
+
+    return LongHorMetric(metrics.width, metrics.xMin);
   }
 
   final int advanceWidth;
@@ -78,13 +88,21 @@ class HorizontalMetricsTable extends FontTable {
     return HorizontalMetricsTable(entry, hMetrics, leftSideBearings);
   }
 
+  /// [advanceWidthOverrides], when given, must have one entry per glyph in
+  /// [glyphMetricsList]; a non-null entry fixes that glyph's advance width
+  /// (see [LongHorMetric.createForGlyph]).
   factory HorizontalMetricsTable.create(
     List<GenericGlyphMetrics> glyphMetricsList,
-    int unitsPerEm,
-  ) {
+    int unitsPerEm, {
+    List<int?>? advanceWidthOverrides,
+  }) {
     final hMetrics = List.generate(
       glyphMetricsList.length,
-      (i) => LongHorMetric.createForGlyph(glyphMetricsList[i], unitsPerEm),
+      (i) => LongHorMetric.createForGlyph(
+        glyphMetricsList[i],
+        unitsPerEm,
+        advanceWidthOverride: advanceWidthOverrides?[i],
+      ),
     );
 
     return HorizontalMetricsTable(null, hMetrics, []);

--- a/lib/src/otf/table/hmtx.dart
+++ b/lib/src/otf/table/hmtx.dart
@@ -25,22 +25,34 @@ class LongHorMetric implements BinaryCodable {
   /// [advanceWidthOverride], when given, replaces the width that would
   /// otherwise be derived from [metrics] — used when a glyph must advance by
   /// a fixed amount (e.g. a full em) regardless of how much of it its own
-  /// ink fills. [lsb] always tracks the glyph's real [GenericGlyphMetrics.xMin]
-  /// so it stays equal to `glyf.xMin`, which TrueType requires.
+  /// ink fills.
+  ///
+  /// [lsb] tracks [metrics]' `xMin` unless [lsbOverride] is given, in which
+  /// case that takes precedence. TrueType requires `hmtx.lsb == glyf.xMin`,
+  /// but [metrics] (see callers) is computed from a glyph's *pre-conversion*
+  /// cubic outline, while `glyf.xMin` comes from the outline TrueType
+  /// actually stores, quadratics approximated from that cubic one — two
+  /// different point sets whose bounding boxes need not agree even when the
+  /// curve they approximate is nominally the same. [lsbOverride] exists so a
+  /// caller who already has the post-conversion `glyf.xMin` in hand (i.e. a
+  /// TrueType build) can pass it straight through instead.
   factory LongHorMetric.createForGlyph(
     GenericGlyphMetrics metrics,
     int unitsPerEm, {
     int? advanceWidthOverride,
+    int? lsbOverride,
   }) {
+    final lsb = lsbOverride ?? metrics.xMin;
+
     if (advanceWidthOverride != null) {
-      return LongHorMetric(advanceWidthOverride, metrics.xMin);
+      return LongHorMetric(advanceWidthOverride, lsb);
     }
 
     if (metrics.width == 0) {
-      return LongHorMetric(unitsPerEm ~/ 3, metrics.xMin);
+      return LongHorMetric(unitsPerEm ~/ 3, lsb);
     }
 
-    return LongHorMetric(metrics.width, metrics.xMin);
+    return LongHorMetric(metrics.width, lsb);
   }
 
   final int advanceWidth;
@@ -88,13 +100,15 @@ class HorizontalMetricsTable extends FontTable {
     return HorizontalMetricsTable(entry, hMetrics, leftSideBearings);
   }
 
-  /// [advanceWidthOverrides], when given, must have one entry per glyph in
-  /// [glyphMetricsList]; a non-null entry fixes that glyph's advance width
-  /// (see [LongHorMetric.createForGlyph]).
+  /// [advanceWidthOverrides] and [lsbOverrides], when given, must each have
+  /// one entry per glyph in [glyphMetricsList]; a non-null entry overrides
+  /// that glyph's advance width or lsb respectively (see
+  /// [LongHorMetric.createForGlyph]).
   factory HorizontalMetricsTable.create(
     List<GenericGlyphMetrics> glyphMetricsList,
     int unitsPerEm, {
     List<int?>? advanceWidthOverrides,
+    List<int?>? lsbOverrides,
   }) {
     final hMetrics = List.generate(
       glyphMetricsList.length,
@@ -102,6 +116,7 @@ class HorizontalMetricsTable extends FontTable {
         glyphMetricsList[i],
         unitsPerEm,
         advanceWidthOverride: advanceWidthOverrides?[i],
+        lsbOverride: lsbOverrides?[i],
       ),
     );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fontify_plus
-version: 0.5.1
+version: 0.5.2
 description: >-
   Converts SVG icons to an OTF font and generates a Flutter-compatible class.
   Outlines stroked icons so outline-style sets render correctly. CLI and API.

--- a/test/src/otf/otf_builder_test.dart
+++ b/test/src/otf/otf_builder_test.dart
@@ -44,9 +44,11 @@ GenericGlyph _offCenterSquareGlyph() {
 /// box happens to bottom out exactly at an anchor — a circle split into
 /// quarters at its own leftmost/rightmost/top/bottom points, for instance —
 /// cannot tell the pre- and post-conversion outlines apart. This one can:
-/// its single cubic segment bulges left from two anchors at x=10 down to
-/// x=4 at its midpoint, so the curve's true leftmost point is interior and
-/// moves by a fraction of a font unit once approximated as quadratics.
+/// its single cubic segment bulges left from two anchors at x=10 towards
+/// control points at x=4, reaching x=5.5 at its midpoint — a curve stays
+/// inside the hull of its controls and never touches them. What matters is
+/// that the leftmost point is interior rather than an anchor, so it moves
+/// once the segment is approximated as quadratics.
 GenericGlyph _offCenterCurvedGlyph() {
   return GenericGlyph.fromSvg(
     'icon',

--- a/test/src/otf/otf_builder_test.dart
+++ b/test/src/otf/otf_builder_test.dart
@@ -1,6 +1,8 @@
 import 'package:fontify_plus/src/common/generic_glyph.dart';
 import 'package:fontify_plus/src/otf/defaults.dart';
 import 'package:fontify_plus/src/otf/otf_builder.dart';
+import 'package:fontify_plus/src/otf/table/glyf.dart';
+import 'package:fontify_plus/src/otf/table/hmtx.dart';
 import 'package:fontify_plus/src/otf/table/post/post_script_data.dart';
 import 'package:fontify_plus/src/otf/table/post/post_script_version_20.dart';
 import 'package:fontify_plus/src/utils/misc.dart';
@@ -15,6 +17,17 @@ GenericGlyph _triangleGlyph() {
   );
 
   return glyph;
+}
+
+/// Drawn away from its artboard's left edge, so its ink's xMin is nonzero
+/// once [ArtboardFitting] maps the artboard straight onto the em square
+/// without centring — unlike [_triangleGlyph], whose ink touches every edge.
+GenericGlyph _offCenterSquareGlyph() {
+  return GenericGlyph.fromSvg(
+    'icon',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
+        '<path d="M6 6 H10 V10 H6 Z"/></svg>',
+  );
 }
 
 void main() {
@@ -116,6 +129,43 @@ void main() {
         expect(font.hhea.descender, 0);
       },
     );
+
+    for (final normalize in [true, false]) {
+      test(
+        'normalize: $normalize keeps hmtx.lsb equal to glyf.xMin for every glyph',
+        () {
+          // TrueType requires hmtx.lsb == glyf.xMin: a rasterizer derives a
+          // glyph's horizontal origin (phantom point pp1) from lsb, and a
+          // mismatch with the outline's own xMin shifts the glyph sideways.
+          final font = OpenTypeFontBuilder(
+            glyphList: [_offCenterSquareGlyph()],
+            useOpenType: false,
+            normalize: normalize,
+          ).build();
+
+          final glyf = (font.tableMap[kGlyfTag]! as GlyphDataTable).glyphList;
+          final hmtx =
+              (font.tableMap[kHmtxTag]! as HorizontalMetricsTable).hMetrics;
+
+          expect(hmtx, hasLength(glyf.length));
+
+          for (var i = 0; i < glyf.length; i++) {
+            // A glyph with no contours (e.g. the default "space" glyph) has
+            // no glyf entry to read an xMin from, so the invariant doesn't
+            // apply to it.
+            if (glyf[i].isEmpty) {
+              continue;
+            }
+
+            expect(
+              hmtx[i].lsb,
+              glyf[i].header.xMin,
+              reason: 'glyph $i',
+            );
+          }
+        },
+      );
+    }
   });
 
   group('OpenTypeFontBuilder post table version', () {

--- a/test/src/otf/otf_builder_test.dart
+++ b/test/src/otf/otf_builder_test.dart
@@ -22,11 +22,36 @@ GenericGlyph _triangleGlyph() {
 /// Drawn away from its artboard's left edge, so its ink's xMin is nonzero
 /// once [ArtboardFitting] maps the artboard straight onto the em square
 /// without centring — unlike [_triangleGlyph], whose ink touches every edge.
+///
+/// Purely straight-lined, so cubicToQuad is a no-op on it: it cannot tell
+/// [glyf.xMin][GlyphHeader.xMin] apart from the pre-conversion cubic
+/// metrics that hmtx used to derive lsb from. See [_offCenterCircleGlyph].
 GenericGlyph _offCenterSquareGlyph() {
   return GenericGlyph.fromSvg(
     'icon',
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
         '<path d="M6 6 H10 V10 H6 Z"/></svg>',
+  );
+}
+
+/// Off-centre like [_offCenterSquareGlyph], but curved, and — unlike a
+/// circle — its leftmost point sits in the *middle* of a curve segment
+/// rather than at an anchor shared with the next one.
+///
+/// That distinction matters: cubicToQuad leaves every anchor point exactly
+/// where it was and only moves the interior of a curve (by approximating
+/// it with a different set of control points), so a shape whose bounding
+/// box happens to bottom out exactly at an anchor — a circle split into
+/// quarters at its own leftmost/rightmost/top/bottom points, for instance —
+/// cannot tell the pre- and post-conversion outlines apart. This one can:
+/// its single cubic segment bulges left from two anchors at x=10 down to
+/// x=4 at its midpoint, so the curve's true leftmost point is interior and
+/// moves by a fraction of a font unit once approximated as quadratics.
+GenericGlyph _offCenterCurvedGlyph() {
+  return GenericGlyph.fromSvg(
+    'icon',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
+        '<path d="M10 4 C4 4 4 12 10 12 L12 12 L12 4 Z"/></svg>',
   );
 }
 
@@ -137,8 +162,12 @@ void main() {
           // TrueType requires hmtx.lsb == glyf.xMin: a rasterizer derives a
           // glyph's horizontal origin (phantom point pp1) from lsb, and a
           // mismatch with the outline's own xMin shifts the glyph sideways.
+          // Both a rectilinear and a curved off-centre glyph are included:
+          // the curved one is the one that can actually catch lsb drifting
+          // away from the post-cubicToQuad glyf.xMin (see
+          // _offCenterCurvedGlyph).
           final font = OpenTypeFontBuilder(
-            glyphList: [_offCenterSquareGlyph()],
+            glyphList: [_offCenterSquareGlyph(), _offCenterCurvedGlyph()],
             useOpenType: false,
             normalize: normalize,
           ).build();

--- a/test/src/otf/table/glyf_test.dart
+++ b/test/src/otf/table/glyf_test.dart
@@ -1,6 +1,8 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:fontify_plus/src/common/generic_glyph.dart';
+import 'package:fontify_plus/src/common/outline.dart';
 import 'package:fontify_plus/src/otf/table/glyf.dart';
 import 'package:fontify_plus/src/otf/table/glyph/flag.dart';
 import 'package:fontify_plus/src/otf/table/glyph/header.dart';
@@ -8,6 +10,62 @@ import 'package:fontify_plus/src/otf/table/glyph/simple.dart';
 import 'package:fontify_plus/src/otf/table/loca.dart';
 import 'package:fontify_plus/src/otf/table/table_record_entry.dart';
 import 'package:test/test.dart';
+
+/// A circle glyph, drawn to exactly fill a square artboard of side
+/// `2 * radius`. Every on-curve point of a correctly-converted outline sits
+/// at precisely [radius] from the artboard's centre, which makes "how far did
+/// the curve drift from [radius]" a direct proxy for outline correctness.
+String _circleSvg(double radius) {
+  final diameter = radius * 2;
+
+  return '<svg xmlns="http://www.w3.org/2000/svg" '
+      'viewBox="0 0 $diameter $diameter">'
+      '<circle cx="$radius" cy="$radius" r="$radius"/></svg>';
+}
+
+/// Evaluates the quadratic bezier through [p0], [p1] (control), [p2] at [t].
+double _quadAt(num p0, num p1, num p2, double t) =>
+    (1 - t) * (1 - t) * p0 + 2 * (1 - t) * t * p1 + t * t * p2;
+
+double _distance(math.Point<num> a, math.Point<num> b) =>
+    math.sqrt((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y));
+
+/// The farthest any point *on* [outline]'s curves gets from [center].
+///
+/// Walks the actual quadratic segments rather than just the stored points:
+/// an off-curve point is a control point, not a point on the curve, so
+/// checking stored points alone would miss curve segments that bulge between
+/// them. [outline] must already be decompacted (see
+/// [Outline.decompactImplicitPoints]) so every off-curve point has an
+/// on-curve neighbour on each side.
+double _maxRadiusOnCurve(Outline outline, math.Point<num> center) {
+  final points = outline.pointList;
+  final isOnCurve = outline.isOnCurveList;
+  var maxDistance = 0.0;
+
+  for (var i = 0; i < points.length; i++) {
+    if (isOnCurve[i]) {
+      maxDistance = math.max(maxDistance, _distance(points[i], center));
+      continue;
+    }
+
+    final p0 = points[i - 1];
+    final p1 = points[i];
+    final p2 = points[(i + 1) % points.length];
+
+    for (var s = 0; s <= 32; s++) {
+      final t = s / 32;
+      final sample = math.Point<num>(
+        _quadAt(p0.x, p1.x, p2.x, t),
+        _quadAt(p0.y, p1.y, p2.y, t),
+      );
+
+      maxDistance = math.max(maxDistance, _distance(sample, center));
+    }
+  }
+
+  return maxDistance;
+}
 
 SimpleGlyph _triangle() {
   final points = [
@@ -81,5 +139,33 @@ void main() {
       expect(decoded.glyphList[0].isEmpty, isTrue);
       expect(decoded.glyphList[1].pointList, _triangle().pointList);
     });
+  });
+
+  group('GlyphDataTable.fromGlyphs cubic-to-quadratic conversion', () {
+    test(
+      'a circle keeps its curve within about 1% of its nominal radius',
+      () {
+        const radius = 170.0;
+        const center = math.Point<double>(radius, radius);
+
+        final glyph = GenericGlyph.fromSvg('circle', _circleSvg(radius));
+        final table = GlyphDataTable.fromGlyphs([glyph]);
+
+        final decoded = GenericGlyph.fromSimpleTrueTypeGlyph(
+          table.glyphList.single,
+        );
+        final outline = decoded.outlines.single..decompactImplicitPoints();
+
+        final maxRadius = _maxRadiusOnCurve(outline, center);
+
+        // Regression guard: an SVG circle is cubic, and TrueType stores only
+        // quadratics. Skipping the cubic-to-quadratic conversion leaves the
+        // cubic control points in place as if they were quadratic ones,
+        // which a rasterizer reads as a curve bulging toward those points —
+        // worst at the 45-degree marks, by roughly 10% of the radius here.
+        // A correct conversion should track the circle within about 1%.
+        expect(maxRadius, closeTo(radius, radius * 0.01));
+      },
+    );
   });
 }


### PR DESCRIPTION
Two bugs in the TrueType (`--no-opentype`) output path, both found while prototyping variable-font support. The default CFF path is byte-identical to 0.5.1.

## Cubic curves were never converted to quadratics

`GlyphDataTable.fromGlyphs` built its working copies with `glyphList.map((e) => e.copy())` — a lazy `Iterable`. The loop applying `cubicToQuad()` and `compactImplicitPoints()` materialised its own copies and discarded them; the encoder then re-iterated and received fresh, unconverted ones. Every TrueType font this package has emitted stored the SVG's cubic control points verbatim as consecutive off-curve points, which a rasterizer reads as quadratics with implied midpoints.

A circle of nominal radius 170 rendered with a maximum radius of 186.6 — a **+9.7% radial bulge** — where the CFF build of the same SVG gives +0.24%. `cubicCurveToQuadratics` and `compactImplicitPoints` were dead code in practice.

This survived every release because nothing tested generated TrueType geometry: `ttf_test.dart` decodes a static asset, and its writer round-trip builds glyphs whose outlines are already flagged as quadratic and compact, so both conversions early-returned.

## `hmtx.lsb` was hardcoded to zero

TrueType requires `hmtx.lsb == glyf.xMin`; FreeType computes the phantom point `pp1.x = xMin - lsb` and translates the outline by `-pp1.x`, so a mismatch shifts the glyph sideways. `lsb` was unconditionally `0`, and under `normalize: false` the real per-glyph metrics were additionally replaced by a full-em placeholder before reaching `hmtx`.

Fixing the conversion above made this worse before it made it better: `head`/`hhea`/`hmtx` derive from the pre-conversion cubic points while `glyf`'s header derives from the post-conversion quadratics, and those two coincided only by accident while the conversion was broken. `lsb` is now sourced from `glyf`'s own header on the TrueType path; CFF keeps deriving from cubic metrics, which is correct because its charstrings encode those same outlines.

## Verification

- Both fixes have a test that fails first: the circle's radius overshoot, and `hmtx.lsb == glyf.xMin` for every glyph in both `normalize` modes. The `lsb` fixture is an asymmetric cubic bulge — a circle is useless here, because its bbox extrema sit on anchor points that the conversion never moves.
- Advance widths verified unchanged: 80 values across 20 build configurations, byte-identical.
- Default CFF + `normalize: true` output verified byte-identical to 0.5.1 with the `head` timestamp pinned.
- 942 tests passing, `dart analyze --fatal-infos` clean.

## Known follow-up, not fixed here

`head`/`hhea` still derive from pre-conversion cubic metrics on the TrueType path. The quadratic control point formula in `bezier.dart` is affine rather than convex, so a converted outline can in principle extend past the cubic-derived bounding box, which would make `head` fail to contain a glyph. Reproducible in isolation on small sharp segments; not reproducible end to end through the full pipeline. Tracked separately rather than adding a third byte-changing fix to a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)