### PR TITLE
Document Flutter-based Cursor Cloud agent setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,14 @@ Publish workflow verifies tag ↔ pubspec and publishes via OIDC. See [CONTRIBUT
 | Run focused tests, then `dart test` before claiming done | Skip e2e after writer/table changes |
 | Ask before committing `docs/superpowers/**` | Commit design/plan scratch by default |
 | Keep example artifacts in sync if defaults change codegen | Leave example fonts stale after intentional regen |
+
+## Cursor Cloud specific instructions
+
+Prefer the **Flutter SDK** (ships Dart) over a standalone Dart install — `example/` is a Flutter app, and agents should be able to run it and Flutter-facing checks. Package unit/integration tests under `test/` are still plain `dart test` and do not need the Flutter framework.
+
+Standard commands: [CONTRIBUTING.md](CONTRIBUTING.md) / Commands above. Cloud gotchas:
+
+- Use Flutter’s `dart`/`flutter` on `PATH` (typically `/opt/flutter/bin`). CI-style package-only deps: `dart pub get --no-example`. With Flutter present, root `dart pub get` also resolves `example/`.
+- Example app: `cd example && dart run tool/generate.dart` then `flutter run -d chrome`. Chrome is the supported device here (web); Android/Linux desktop toolchains are optional and not required for this repo.
+- Regenerating the example updates committed `example/fonts/` and `example/lib/my_icons.dart` — only commit those when the change is intentional.
+- `dart analyze --fatal-infos` matches CI; format is pinned on stable (`dart format --output=none --set-exit-if-changed bin lib test`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `## Cursor Cloud specific instructions` to `AGENTS.md` so future cloud agents prefer the Flutter SDK (which ships Dart) for this repo’s `example/` Flutter app and cloud workflows.

## Notes for reviewers

- Package tests remain plain `dart test` (no Flutter framework required).
- Documents Chrome web as the supported example device and when not to commit regenerated example fonts.
- Update script for cloud VMs: `dart pub get` (resolves package + `example/` when Flutter is on `PATH`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa8f004e-68b0-4ea0-8d39-cd64c3a66d69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa8f004e-68b0-4ea0-8d39-cd64c3a66d69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

